### PR TITLE
Testing time decoding

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "*"
+  schedule:
+    - cron: "0 13 * * 1"
+
+jobs:
+  build:
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.9", "3.10", "3.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: 🫙 Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # checkout tags (which is not done by default)
+      - name: 🔁 Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: 🌈 Install dependencies
+        shell: bash -l {0}
+        run: |
+          python -m pip install -r requirements.txt
+      - name: 🏄‍♂️ Run Tests
+        shell: bash -l {0}
+        run: |
+          pytest tests -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-git+https://github.com/TomAugspurger/VirtualiZarr.git@user/tom/feature/filesystems
+git+https://github.com/jsignell/VirtualiZarr.git@cftime
 kerchunk
 xarray
 requests
 aiohttp
 tqdm
 dask
+cftime
+pytest

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,0 +1,81 @@
+import pytest
+import xarray as xr
+import fsspec
+from virtualizarr import open_virtual_dataset
+
+urls = [
+    "http://aims3.llnl.gov/thredds/fileServer/css03_data/CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/Amon/tas/gn/v20190710/tas_Amon_MPI-ESM1-2-HR_ssp126_r1i1p1f1_gn_201501-201912.nc",
+    "http://aims3.llnl.gov/thredds/fileServer/css03_data/CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/Amon/tas/gn/v20190710/tas_Amon_MPI-ESM1-2-HR_ssp126_r1i1p1f1_gn_202001-202412.nc",
+    # "http://aims3.llnl.gov/thredds/fileServer/css03_data/CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/Amon/tas/gn/v20190710/tas_Amon_MPI-ESM1-2-HR_ssp126_r1i1p1f1_gn_202501-202912.nc",
+    # "http://aims3.llnl.gov/thredds/fileServer/css03_data/CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp126/r1i1p1f1/Amon/tas/gn/v20190710/tas_Amon_MPI-ESM1-2-HR_ssp126_r1i1p1f1_gn_203001-203412.nc",
+]
+
+@pytest.fixture()
+def ds_combined():
+    ds_list = []
+    for url in urls:
+        with fsspec.open(url) as f:
+            ds = xr.open_dataset(f).load() #workaround from https://github.com/fsspec/s3fs/issues/337
+        ds_list.append(ds)
+    return xr.combine_nested(
+        ds_list,
+        concat_dim=["time"],
+        coords="minimal",
+        compat="override",
+        combine_attrs="drop_conflicts",
+    )
+
+@pytest.fixture(scope="module")
+def vds():
+    # load virtual datasets in serial
+    vds_list = []
+    for url in urls:
+        vds = open_virtual_dataset(
+            url, indexes={}, 
+            reader_options={}, # needed for now to circumvent a bug in https://github.com/TomNicholas/VirtualiZarr/pull/126
+            cftime_variables=["time"],
+            loadable_variables=["time"],
+        )
+        vds_list.append(vds)
+
+    combined_vds = xr.combine_nested(
+        vds_list,
+        concat_dim=["time"],
+        coords="minimal",
+        compat="override",
+        combine_attrs="drop_conflicts",
+    )
+    return combined_vds
+
+@pytest.fixture(scope="module")
+def vds_json(vds, tmpdir_factory):
+    json_filename = str(tmpdir_factory.mktemp('data').join("combined_full.json"))
+    vds.virtualize.to_kerchunk(json_filename, format="json")
+    return json_filename
+
+def ds_from_json(json_filename, **kwargs):
+    return xr.open_dataset(
+        json_filename, 
+        engine='kerchunk',
+        **kwargs
+    )
+
+def test_load(vds_json):
+    ds = ds_from_json(vds_json)
+    ds_mean = ds.mean().load()
+    assert ds_mean is not None
+
+@pytest.mark.parametrize('use_cftime', [True, False])
+@pytest.mark.parametrize('chunks', [None, {}])
+def test_time(vds_json, ds_combined, chunks, use_cftime):
+    ds = ds_from_json(vds_json, chunks=chunks, use_cftime=use_cftime)
+    print(f"{ds=}")
+    print(f"{ds_combined=}")
+    def clean_time(ds: xr.Dataset) -> xr.DataArray:
+        return ds.time.reset_coords(drop=True).load()
+    xr.testing.assert_identical(clean_time(ds), clean_time(ds_combined))
+    
+
+
+# def test_assert_equal(ds_from_json, ds_combined):
+#     xr.testing.assert_allclose(ds_from_json, ds_combined)

--- a/virtual-zarr-script.py
+++ b/virtual-zarr-script.py
@@ -16,7 +16,8 @@ json_filename = "combined_full.json"
 vds_list = []
 for url in tqdm(urls):
     vds = open_virtual_dataset(
-        url, indexes={}, reader_options={}
+        url, indexes={}, 
+        # reader_options={}
     )  # reader_options={} is needed for now to circumvent a bug in https://github.com/TomNicholas/VirtualiZarr/pull/126
     vds_list.append(vds)
 
@@ -29,7 +30,7 @@ combined_vds = xr.combine_nested(
 )
 combined_vds.virtualize.to_kerchunk(json_filename, format="json")
 
-## test load and print the the mean of the output
+## load and testthe output
 print(f"Loading the mean of the virtual dataset from {json_filename=}")
 
 ds = xr.open_dataset(
@@ -40,4 +41,9 @@ ds = xr.open_dataset(
 print(f"Dataset before mean: {ds}")
 with ProgressBar():
     ds_mean = ds.mean().load()
-print(ds_mean) 
+print(ds_mean)
+
+print("Checking time decoding")
+
+
+


### PR DESCRIPTION
I am testing https://github.com/zarr-developers/VirtualiZarr/pull/122 on my CMIP example. 

As part of this CI, I have set up a pytest module to create and test virtual datasets. 

My current [test for decoded time](https://github.com/jbusecke/esgf-virtual-zarr-data-access/blob/1c80eec6b408206f29631551c7ab63b40204d34e/tests/test_script.py#L68-L76) does indicate the the data seems to be decoded, but there are different attributes compared to a dataset that was loaded straight from http and then concatenated.

```
>       xr.testing.assert_identical(clean_time(ds), clean_time(ds_combined))
E       AssertionError: Left and right DataArray objects are not identical
E
E       Differing coordinates:
E       L * time     (time) datetime64[ns] 960B 2015-01-16T12:00:00 ... 2024-12-16T12...
E           Differing variable attributes:
E               chunksizes: [1]
E               fletcher32: False
E               shuffle: False
E               preferred_chunks: {'time': 1}
E               source: <File-like object HTTPFileSystem, http://aims3.llnl.gov/thredds/f...
E               original_shape: [60]
E               dtype: float64
E       R * time     (time) datetime64[ns] 960B 2015-01-16T12:00:00 ... 2024-12-16T12...
E       Attributes only on the left object:
E           original_shape: [60]
E           chunksizes: [1]
E           fletcher32: False
E           source: <File-like object HTTPFileSystem, http://aims3.llnl.gov/thredds/f...
E           shuffle: False
E           preferred_chunks: {'time': 1}
E           dtype: float64

tests/test_script.py:76: AssertionError
```

> L in this case is the dataset loaded from the virtualizarr json, R is the 'ground truth'

I wonder if this is relevant or not in this usecase?